### PR TITLE
Update Plugin Compatibility to IntelliJ IDEA 2023.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Code Complexity Changelog
 
+## [1.3.0]
+- Changed: Updated the plugin compatibility version to 2023.3. Users on 2023.3 and later can now use the plugin.
+
 ## [1.2.1]
 - Showing of the complexity icon now can be disabled via Settings -> Tools -> Code Complexity
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,19 +4,19 @@ pluginGroup = com.github.nikolaikopernik.codecomplexity
 pluginName = code-complexity-plugin
 pluginRepositoryUrl = https://github.com/nikolaikopernik/code-complexity-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.2.1
+pluginVersion = 1.3.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 232
-pluginUntilBuild = 232.*
+pluginSinceBuild = 233
+pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2023.2
+platformVersion = 2023.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = org.jetbrains.kotlin, com.intellij.java, PythonCore:232.8660.185
+platformPlugins = org.jetbrains.kotlin, com.intellij.java, PythonCore:233.11799.241
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ annotations = "24.0.1"
 dokka = "1.8.10"
 kotlin = "1.8.20"
 changelog = "2.0.0"
-gradleIntelliJPlugin = "1.13.3"
+gradleIntelliJPlugin = "1.16.0"
 qodana = "0.1.13"
 kover = "0.6.1"
 


### PR DESCRIPTION
This PR updates the compatibility version of the plugin to support IntelliJ IDEA 2023.3.

## Changes

- Updated the plugin version compatibility from IntelliJ IDEA 2023.2 to 2023.3 series

This change allows users with IntelliJ IDEA version 2023.3 or later to use our plugin. Please ensure that your IntelliJ IDEA is updated to the latest version before installing the plugin.

Please review and merge this PR when ready.

## Affected Versions

The changes are applicable to the upcoming plugin version. Users of the plugin with IntelliJ IDEA 2023.2 series are advised to update their IDE to 2023.3 series for continued support.
